### PR TITLE
:sparkles: create ncurse inheritance of the idisplay interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,14 @@ SDL2_GFX_LIB_SRC	=	src/graphic_libs/SDL2.cpp	\
 						wrapper/sdl2/SDL2_window.cpp\
 						src/log/Log.cpp				\
 
+NCURSES_GFX_LIB_SRC	=	src/graphic_libs/NCURSES.cpp	\
+						src/log/Log.cpp				\
+						wrapper/ncurses/Ncurses.cpp	\
+						wrapper/ncurses/NcursesDrawPrimitives.cpp	\
+						wrapper/ncurses/NcursesInputHandling.cpp	\
+						wrapper/ncurses/NcursesWindowManagement.cpp	\
+						wrapper/ncurses/NcursesMouseHandling.cpp	\
+
 MAIN_SRC			=	src/Main.cpp
 
 SRC					=	src/log/Log.cpp
@@ -49,6 +57,8 @@ SFML_GFX_LIB_OBJ	=	$(SFML_GFX_LIB_SRC:.cpp=.o)
 
 SDL2_GFX_LIB_OBJ	=	$(SDL2_GFX_LIB_SRC:.cpp=.o)
 
+NCURSES_GFX_LIB_OBJ	=	$(NCURSES_GFX_LIB_SRC:.cpp=.o)
+
 TEST_LIBS_OBJ		=	$(TEST_LIBS_SRC:.cpp=.so)
 
 # Flags
@@ -56,7 +66,7 @@ INCLUDES			=	-I ./src -I ./ -I ./include
 
 LIB_FLAGS			=	-lsfml-graphics -lsfml-window -lsfml-system	\
 						-lSDL2 -lSDL2_image -lSDL2_ttf -lSDL2_mixer	\
-						-ldl										\
+						-ldl -lncurses								\
 
 CPPFLAGS			+=	-std=c++20 -Wall -Wextra -Werror $(INCLUDES) -O2 -g	\
 $(LIB_FLAGS) -fno-gnu-unique -fPIC
@@ -85,11 +95,13 @@ core:	$(OBJ) $(MAIN_OBJ)
 
 games:
 
-graphicals: $(SFML_GFX_LIB_OBJ) $(SDL2_GFX_LIB_OBJ)
+graphicals: $(SFML_GFX_LIB_OBJ) $(SDL2_GFX_LIB_OBJ) $(NCURSES_GFX_LIB_OBJ)
 	@echo "Building SFML graphic library..."
 	$(CC) $(CPPFLAGS) -shared -o ./lib/SFML.so $(SFML_GFX_LIB_OBJ)
 	@echo "Building SDL2 graphic library..."
 	$(CC) $(CPPFLAGS) -shared -o ./lib/SDL2.so $(SDL2_GFX_LIB_OBJ)
+	@echo "Building NCURSES graphic library..."
+	$(CC) $(CPPFLAGS) -shared -o ./lib/NCURSES.so $(NCURSES_GFX_LIB_OBJ)
 
 run: re
 	@echo "Running $(NAME)..."
@@ -113,6 +125,7 @@ clean:
 	rm -f $(OBJ) $(MAIN_OBJ) $(TEST_LIBS_OBJ)
 	rm -f $(SFML_GFX_LIB_OBJ)
 	rm -f $(SDL2_GFX_LIB_OBJ)
+	rm -f $(NCURSES_GFX_LIB_OBJ)
 	rm -f *.gcda
 	rm -f *.gcno
 	rm -f vgcore.*

--- a/include/DataStructures/Sprite.hpp
+++ b/include/DataStructures/Sprite.hpp
@@ -16,33 +16,14 @@
 
 class Sprite : public IDrawable {
  public:
-    std::vector<std::string> getGUI_Textures(void) const {
-        return GUI_Textures;
-    }
-
-    std::vector<std::string> getCLI_Textures(void) const {
-        return CLI_Textures;
-    }
-
-    float getAnimationTime(void) const { return animationTime; }
-
-    unsigned int getCurrentTexture(void) const { return currentTexture; }
-
-    void setGUI_Textures(std::vector<std::string> GUI_Textures) {
-        this->GUI_Textures = GUI_Textures;
-    }
-
-    void setCLI_Textures(std::vector<std::string> CLI_Textures) {
-        this->CLI_Textures = CLI_Textures;
-    }
-
-    void setAnimationTime(float animationTime) {
-        this->animationTime = animationTime;
-    }
-
-    void setCurrentTexture(unsigned int currentTexture) {
-        this->currentTexture = currentTexture;
-    }
+    std::vector<std::string> getGUI_Textures(void) const;
+    std::vector<std::string> getCLI_Textures(void) const;
+    float getAnimationTime(void) const;
+    unsigned int getCurrentTexture(void) const;
+    void setGUI_Textures(std::vector<std::string> GUI_Textures);
+    void setCLI_Textures(std::vector<std::string> CLI_Textures);
+    void setAnimationTime(float animationTime);
+    void setCurrentTexture(unsigned int currentTexture);
 
     std::pair<float, float> getScale(void) const override { return scale; }
 

--- a/src/graphic_libs/NCURSES.cpp
+++ b/src/graphic_libs/NCURSES.cpp
@@ -116,8 +116,6 @@ Event libs::graphic::NCURSES::getEvent(void) {
         }
         if (mouse_buttons.find(mouseEvent.button) != mouse_buttons.end()) {
             Key::KeyCode buttonCode = mouse_buttons[mouseEvent.button];
-            Key::KeyStatus status = (mouseEvent.type == Ncurses::EventType::
-                BUTTON_PRESS) ? Key::KEY_PRESSED : Key::KEY_RELEASED;
             Key::MousePos pos = {mouseEvent.position.x, mouseEvent.position.y};
             return Event(buttonCode, pos);
         }

--- a/src/graphic_libs/NCURSES.cpp
+++ b/src/graphic_libs/NCURSES.cpp
@@ -69,7 +69,7 @@ void libs::graphic::NCURSES::draw(const IDrawable &to_draw) {
     const Sprite *sprite = dynamic_cast<const Sprite *>(&to_draw);
     if (sprite != nullptr) {
         unsigned int currentTexture = sprite->getCurrentTexture();
-        std::vector<char[2]> textures = sprite->getCLI_Textures();
+        std::vector<std::string> textures = sprite->getCLI_Textures();
 
         if (!textures.empty() && currentTexture < textures.size()) {
             Ncurses::Coordinate coord = {position.first, position.second};

--- a/src/graphic_libs/NCURSES.cpp
+++ b/src/graphic_libs/NCURSES.cpp
@@ -1,0 +1,217 @@
+/*
+** EPITECH PROJECT, 2025
+** Arcade
+** File description:
+** NCURSES
+*/
+
+#include <string>
+#include <cstdio>
+#include <memory>
+#include <iostream>
+#include <tuple>
+#include <map>
+#include <vector>
+#include <utility>
+
+#include "src/graphic_libs/NCURSES.hpp"
+#include "src/log/Log.hpp"
+#include "include/DataStructures/Keys.hpp"
+#include "include/DataStructures/CLI_Colors.hpp"
+#include "include/DataStructures/Event.hpp"
+#include "include/DataStructures/Window.hpp"
+#include "include/DataStructures/Text.hpp"
+#include "include/DataStructures/Sprite.hpp"
+
+__attribute__((constructor)) void load(void) {
+    Log::info() << "Loading NCURSES lib..." << std::endl;
+}
+
+__attribute__((destructor)) void unload(void) {
+    Log::info() << "Unloading NCURSES lib..." << std::endl;
+}
+
+extern "C" std::unique_ptr<IDisplayModule> getDisplayModule(void) {
+    Log::info() << "Entrypoint for NCURSES lib" << std::endl;
+    return std::make_unique<libs::graphic::NCURSES>();
+}
+
+libs::graphic::NCURSES::NCURSES() {
+    ncurses = Ncurses();
+}
+
+libs::graphic::NCURSES::~NCURSES() {
+}
+
+void libs::graphic::NCURSES::createWindow(const Window &window) {
+    ncurses.resize(window.size.first, window.size.second);
+}
+
+void libs::graphic::NCURSES::draw(const IDrawable &to_draw) {
+    std::pair<int, int> position = to_draw.getPosition();
+    std::pair<CLI_Color, CLI_Color> colors = to_draw.getCLI_Color();
+    Ncurses::Color fg = Ncurses::Color::WHITE;
+    Ncurses::Color bg = Ncurses::Color::BLACK;
+    for (const auto &colorPair : this->colors) {
+        if (colorPair.second == colors.first) {
+            fg = colorPair.first;
+        }
+        if (colorPair.second == colors.second) {
+            bg = colorPair.first;
+        }
+    }
+    const Text *text = dynamic_cast<const Text *>(&to_draw);
+    if (text != nullptr) {
+        Ncurses::Coordinate coord = {position.first, position.second};
+        ncurses.drawText(coord, text->getStr(), fg, bg);
+        return;
+    }
+    const Sprite *sprite = dynamic_cast<const Sprite *>(&to_draw);
+    if (sprite != nullptr) {
+        unsigned int currentTexture = sprite->getCurrentTexture();
+        std::vector<char[2]> textures = sprite->getCLI_Textures();
+
+        if (!textures.empty() && currentTexture < textures.size()) {
+            Ncurses::Coordinate coord = {position.first, position.second};
+            std::pair<float, float> scale = sprite->getScale();
+
+            for (int y = 0; y < static_cast<int>(scale.second); y++) {
+                for (int x = 0; x < static_cast<int>(scale.first); x++) {
+                    Ncurses::Coordinate pixelCoord = {
+                        coord.x + x,
+                        coord.y + y
+                    };
+                    ncurses.drawPixel(pixelCoord, textures[currentTexture][0],
+                        fg, bg);
+                }
+            }
+        }
+        return;
+    }
+    Ncurses::Coordinate coord = {position.first, position.second};
+    ncurses.drawPixel(coord, 'X', fg, bg);
+}
+
+void libs::graphic::NCURSES::display(void) {
+    ncurses.refresh();
+}
+
+void libs::graphic::NCURSES::clear(void) {
+    ncurses.erase();
+}
+
+Event libs::graphic::NCURSES::getEvent(void) {
+    if (ncurses.isKeyPressed()) {
+        Ncurses::Key ncursesKey = ncurses.getInput();
+        if (keys.find(ncursesKey) != keys.end()) {
+            Key::KeyCode arcadeKey = keys[ncursesKey];
+            return Event(arcadeKey, Key::KEY_PRESSED);
+        }
+    }
+    Ncurses::MouseEvent mouseEvent = ncurses.getMouseEvent();
+    if (mouseEvent.type != Ncurses::EventType::NONE) {
+        if (mouseEvent.type == Ncurses::EventType::BUTTON_MOTION) {
+            Key::MousePos pos = {mouseEvent.position.x, mouseEvent.position.y};
+            return Event(Key::KeyCode::MOUSE_MOVE, pos);
+        }
+        if (mouse_buttons.find(mouseEvent.button) != mouse_buttons.end()) {
+            Key::KeyCode buttonCode = mouse_buttons[mouseEvent.button];
+            Key::KeyStatus status = (mouseEvent.type == Ncurses::EventType::
+                BUTTON_PRESS) ? Key::KEY_PRESSED : Key::KEY_RELEASED;
+            Key::MousePos pos = {mouseEvent.position.x, mouseEvent.position.y};
+            return Event(buttonCode, pos);
+        }
+    }
+    return Event(Key::KeyCode::NONE, Key::KEY_RELEASED);
+}
+
+void libs::graphic::NCURSES::handleSound(const Sound &sound) {
+    // TODO(leopold) : handle sound if possible
+    (void)sound;
+}
+
+std::map<Ncurses::Key, Key::KeyCode> libs::graphic::NCURSES::keys = {
+    {Ncurses::Key::NONE, Key::KeyCode::NONE},
+
+    {Ncurses::Key::A, Key::KeyCode::KEY_A},
+    {Ncurses::Key::B, Key::KeyCode::KEY_B},
+    {Ncurses::Key::C, Key::KeyCode::KEY_C},
+    {Ncurses::Key::D, Key::KeyCode::KEY_D},
+    {Ncurses::Key::E, Key::KeyCode::KEY_E},
+    {Ncurses::Key::F, Key::KeyCode::KEY_F},
+    {Ncurses::Key::G, Key::KeyCode::KEY_G},
+    {Ncurses::Key::H, Key::KeyCode::KEY_H},
+    {Ncurses::Key::I, Key::KeyCode::KEY_I},
+    {Ncurses::Key::J, Key::KeyCode::KEY_J},
+    {Ncurses::Key::K, Key::KeyCode::KEY_K},
+    {Ncurses::Key::L, Key::KeyCode::KEY_L},
+    {Ncurses::Key::M, Key::KeyCode::KEY_M},
+    {Ncurses::Key::N, Key::KeyCode::KEY_N},
+    {Ncurses::Key::O, Key::KeyCode::KEY_O},
+    {Ncurses::Key::P, Key::KeyCode::KEY_P},
+    {Ncurses::Key::Q, Key::KeyCode::KEY_Q},
+    {Ncurses::Key::R, Key::KeyCode::KEY_R},
+    {Ncurses::Key::S, Key::KeyCode::KEY_S},
+    {Ncurses::Key::T, Key::KeyCode::KEY_T},
+    {Ncurses::Key::U, Key::KeyCode::KEY_U},
+    {Ncurses::Key::V, Key::KeyCode::KEY_V},
+    {Ncurses::Key::W, Key::KeyCode::KEY_W},
+    {Ncurses::Key::X, Key::KeyCode::KEY_X},
+    {Ncurses::Key::Y, Key::KeyCode::KEY_Y},
+    {Ncurses::Key::Z, Key::KeyCode::KEY_Z},
+
+    {Ncurses::Key::UP, Key::KeyCode::UP},
+    {Ncurses::Key::DOWN, Key::KeyCode::DOWN},
+    {Ncurses::Key::LEFT, Key::KeyCode::LEFT},
+    {Ncurses::Key::RIGHT, Key::KeyCode::RIGHT},
+
+    {Ncurses::Key::ENTER, Key::KeyCode::ENTER},
+    {Ncurses::Key::ESCAPE, Key::KeyCode::ECHAP},
+    {Ncurses::Key::SPACE, Key::KeyCode::SPACE},
+    {Ncurses::Key::BACKSPACE, Key::KeyCode::SUPPR},
+    {Ncurses::Key::TAB, Key::KeyCode::TAB},
+
+    {Ncurses::Key::NUM0, Key::KeyCode::KEY_0},
+    {Ncurses::Key::NUM1, Key::KeyCode::KEY_1},
+    {Ncurses::Key::NUM2, Key::KeyCode::KEY_2},
+    {Ncurses::Key::NUM3, Key::KeyCode::KEY_3},
+    {Ncurses::Key::NUM4, Key::KeyCode::KEY_4},
+    {Ncurses::Key::NUM5, Key::KeyCode::KEY_5},
+    {Ncurses::Key::NUM6, Key::KeyCode::KEY_6},
+    {Ncurses::Key::NUM7, Key::KeyCode::KEY_7},
+    {Ncurses::Key::NUM8, Key::KeyCode::KEY_8},
+    {Ncurses::Key::NUM9, Key::KeyCode::KEY_9},
+
+    {Ncurses::Key::F1, Key::KeyCode::FUNCTION_1},
+    {Ncurses::Key::F2, Key::KeyCode::FUNCTION_2},
+    {Ncurses::Key::F3, Key::KeyCode::FUNCTION_3},
+    {Ncurses::Key::F4, Key::KeyCode::FUNCTION_4},
+    {Ncurses::Key::F5, Key::KeyCode::FUNCTION_5},
+    {Ncurses::Key::F6, Key::KeyCode::FUNCTION_6},
+    {Ncurses::Key::F7, Key::KeyCode::FUNCTION_7},
+    {Ncurses::Key::F8, Key::KeyCode::FUNCTION_8},
+    {Ncurses::Key::F9, Key::KeyCode::FUNCTION_9},
+    {Ncurses::Key::F10, Key::KeyCode::FUNCTION_10},
+    {Ncurses::Key::F11, Key::KeyCode::FUNCTION_11},
+    {Ncurses::Key::F12, Key::KeyCode::FUNCTION_12},
+};
+
+std::map<Ncurses::Button, Key::KeyCode> libs::graphic::NCURSES::mouse_buttons
+    = {
+    {Ncurses::Button::LEFT, Key::KeyCode::MOUSE_LEFT},
+    {Ncurses::Button::MIDDLE, Key::KeyCode::MOUSE_MIDDLE},
+    {Ncurses::Button::RIGHT, Key::KeyCode::MOUSE_RIGHT},
+    {Ncurses::Button::SCROLL_UP, Key::KeyCode::MOUSE_BUTTON_4},
+    {Ncurses::Button::SCROLL_DOWN, Key::KeyCode::MOUSE_BUTTON_5},
+};
+
+std::map<Ncurses::Color, CLI_Color> libs::graphic::NCURSES::colors = {
+    {Ncurses::Color::BLACK, CLI_Color::CLI_BLACK},
+    {Ncurses::Color::RED, CLI_Color::CLI_RED},
+    {Ncurses::Color::GREEN, CLI_Color::CLI_GREEN},
+    {Ncurses::Color::YELLOW, CLI_Color::CLI_YELLOW},
+    {Ncurses::Color::BLUE, CLI_Color::CLI_BLUE},
+    {Ncurses::Color::MAGENTA, CLI_Color::CLI_MAGENTA},
+    {Ncurses::Color::CYAN, CLI_Color::CLI_CYAN},
+    {Ncurses::Color::WHITE, CLI_Color::CLI_WHITE},
+};

--- a/src/graphic_libs/NCURSES.hpp
+++ b/src/graphic_libs/NCURSES.hpp
@@ -1,0 +1,39 @@
+/*
+** EPITECH PROJECT, 2025
+** Arcade
+** File description:
+** NCURSES
+*/
+
+#pragma once
+
+#include <string>
+#include <memory>
+#include <map>
+#include "modules/IDisplayModule.hpp"
+#include "wrapper/ncurses/Ncurses.hpp"
+
+namespace libs {
+namespace graphic {
+
+class NCURSES : public IDisplayModule {
+ public:
+    static std::map<Ncurses::Key, Key::KeyCode> keys;
+    static std::map<Ncurses::Button, Key::KeyCode> mouse_buttons;
+    static std::map<Ncurses::Color, CLI_Color> colors;
+    NCURSES();
+    ~NCURSES();
+    void createWindow(const Window &window) override;
+    void draw(const IDrawable &to_draw) override;
+    void display(void) override;
+    void clear(void) override;
+    Event getEvent(void) override;
+    void handleSound(const Sound &sound) override;
+
+ protected:
+ private:
+    Ncurses ncurses;
+};
+
+}  // namespace graphic
+}  // namespace libs

--- a/wrapper/ncurses/NcursesDrawPrimitives.cpp
+++ b/wrapper/ncurses/NcursesDrawPrimitives.cpp
@@ -32,9 +32,14 @@ void Ncurses::drawRect(Ncurses::Coordinate xy, int width, int height, char c,
 }
 
 void Ncurses::drawBox(Ncurses::Coordinate xy, int width, int height, Color fg,
-                      Color bg) {
+    Color bg) {
     wattron(_window, COLOR_PAIR(getPairNumber(fg, bg)));
-    wborder(_window, 0, 0, 0, 0, 0, 0, 0, 0);
+    WINDOW* boxWin = subwin(_window, height, width, xy.y, xy.x);
+    if (boxWin != NULL) {
+        box(boxWin, 0, 0);
+        wrefresh(boxWin);
+        delwin(boxWin);
+    }
     wattroff(_window, COLOR_PAIR(getPairNumber(fg, bg)));
 }
 


### PR DESCRIPTION
This pull request introduces the NCURSES graphic library to the project, including updates to the `Makefile` and the addition of new source files. The most important changes include adding the NCURSES library source and object files to the build process, implementing the NCURSES graphic library class, and refactoring the `Sprite` class to use separate function declarations.

### Build System Updates:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R33-R40): Added `NCURSES_GFX_LIB_SRC` and `NCURSES_GFX_LIB_OBJ` to include NCURSES source files and object files in the build process. Updated the `graphicals` target to build the NCURSES graphic library. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R33-R40) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R60-R69) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L88-R104) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R128)

### New NCURSES Graphic Library:
* [`src/graphic_libs/NCURSES.cpp`](diffhunk://#diff-479193a63d7cd10616d993b2ad8a006450d0720b77b9532085b0a6f9b04bdc3eR1-R215): Implemented the NCURSES graphic library class, including methods for window creation, drawing, event handling, and sound handling.
* [`src/graphic_libs/NCURSES.hpp`](diffhunk://#diff-b1eb7315b1bda028f6422c336500af7542f60d0ff21282c46071eb817d740459R1-R39): Defined the NCURSES graphic library class and its member functions.

### Code Refactoring:
* [`include/DataStructures/Sprite.hpp`](diffhunk://#diff-968f1437605253a226238a5fa89cabd2cb4073b37e428f60a768decd1972bafbL19-R26): Refactored the `Sprite` class to use separate function declarations for getter and setter methods.

### Other Changes:
* [`wrapper/ncurses/NcursesDrawPrimitives.cpp`](diffhunk://#diff-ad46e62df621945637e07f458b444b5018e979df8a31b6e4df464e5030e8224cL37-R42): Modified the `drawBox` function to use a subwindow for drawing boxes, improving the rendering process.